### PR TITLE
Update gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "2.0.0"
     id("java-gradle-plugin")
     id("maven-publish")
 }
@@ -9,6 +12,21 @@ group = "com.lagradost.cloudstream3"
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        // Disables some unnecessary features
+        freeCompilerArgs.addAll(
+            listOf(
+                "-Xno-call-assertions",
+                "-Xno-param-assertions",
+                "-Xno-receiver-assertions"
+            )
+        )
+
+        jvmTarget.set(JvmTarget.JVM_11)  // Required
+    }
 }
 
 repositories {
@@ -23,9 +41,9 @@ dependencies {
 
     compileOnly("com.google.guava:guava:30.1.1-jre")
     compileOnly("com.android.tools:sdk-common:30.0.0")
-    compileOnly("com.android.tools.build:gradle:7.2.2")
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
-    
+    compileOnly("com.android.tools.build:gradle:8.7.3")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
+
     implementation("org.ow2.asm:asm:9.4")
     implementation("org.ow2.asm:asm-tree:9.4")
     implementation("com.github.vidstige:jadb:master-SNAPSHOT")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompileDexTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompileDexTask.kt
@@ -47,16 +47,20 @@ abstract class CompileDexTask : DefaultTask() {
                     minSdkVersion = minSdk,
                     debuggable = true,
                     dexPerClass = false,
-                    withDesugaring = minSdk >= 24,
+                    withDesugaring = true, // Make all plugins work on lower android versions
                     desugarBootclasspath = ClassFileProviderFactory(android.bootClasspath.map(File::toPath))
                         .also { closer.register(it) },
-                    desugarClasspath = ClassFileProviderFactory(listOf<Path>()).also { closer.register(it) },
+                    desugarClasspath = ClassFileProviderFactory(listOf<Path>()).also {
+                        closer.register(
+                            it
+                        )
+                    },
                     coreLibDesugarConfig = null,
-                    coreLibDesugarOutputKeepRuleFile = null,
                     messageReceiver = MessageReceiverImpl(
                         ErrorFormatMode.HUMAN_READABLE,
                         LoggerFactory.getLogger(CompileDexTask::class.java)
-                    )
+                    ),
+                    enableApiModeling = false // Unknown option, setting to false seems to work
                 )
             )
 
@@ -70,7 +74,8 @@ abstract class CompileDexTask : DefaultTask() {
 
                     dexBuilder.convert(
                         files.stream(),
-                        dexOutputDir.toPath()
+                        dexOutputDir.toPath(),
+                        null,
                     )
 
                     for (file in files) {

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/DeployWithAdbTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/DeployWithAdbTask.kt
@@ -43,6 +43,10 @@ abstract class DeployWithAdbTask : DefaultTask() {
 
         device.push(file, RemoteFile(path + file.name))
 
+        // Make the file readonly to work on newer android versions, this does not impact adb push.
+        // https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading
+        device.executeShell("chmod", "-w", path + file.name)
+
         val args = arrayListOf("start", "-a", "android.intent.action.VIEW", "-d", "cloudstreamapp:")
 
         if (waitForDebugger) {

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
@@ -1,7 +1,6 @@
 package com.lagradost.cloudstream3.gradle.tasks
 
 import com.lagradost.cloudstream3.gradle.getCloudstream
-import com.lagradost.cloudstream3.gradle.entities.PluginManifest
 import com.lagradost.cloudstream3.gradle.makeManifest
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.tasks.ProcessLibraryManifest
@@ -12,7 +11,6 @@ import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import com.lagradost.cloudstream3.gradle.findCloudstream
 
 const val TASK_GROUP = "cloudstream"
 
@@ -47,11 +45,13 @@ fun registerTasks(project: Project) {
             it.input.from(kotlinTask.destinationDirectory)
         }
 
-        val javacTask = project.tasks.findByName("compileDebugJavaWithJavac") as AbstractCompile?
-        if (javacTask != null) {
-            it.dependsOn(javacTask)
-            it.input.from(javacTask.destinationDirectory)
-        }
+        // This task does not seem to be required for a successful cs3 file
+
+//        val javacTask = project.tasks.findByName("compileDebugJavaWithJavac") as AbstractCompile?
+//        if (javacTask != null) {
+//            it.dependsOn(javacTask)
+//            it.input.from(javacTask.destinationDirectory)
+//        }
 
         it.outputFile.set(intermediates.resolve("classes.dex"))
     }


### PR DESCRIPTION
This makes gradle work with the recent app updates. The adb task also makes dex files read-only which is required on recent android versions now. 

Test it locally by running:
`./gradlew build publishToMavenLocal`

Then in extension repository build.gradle.kts (tested on https://github.com/recloudstream/extensions):
```kt
import com.lagradost.cloudstream3.gradle.CloudstreamExtension 
import com.android.build.gradle.BaseExtension
import org.jetbrains.kotlin.gradle.dsl.JvmTarget
import org.jetbrains.kotlin.gradle.tasks.KotlinCompile

buildscript {
    repositories {
        mavenLocal()
        google()
        mavenCentral()
        // Shitpack repo which contains our tools and dependencies
        maven("https://jitpack.io")
    }

    dependencies {
        classpath("com.android.tools.build:gradle:8.7.3")
        // Cloudstream gradle plugin which makes everything work and builds plugins
        // classpath("com.github.recloudstream:gradle:-SNAPSHOT") // Online
        classpath("com.lagradost.cloudstream3:gradle:local-SNAPSHOT") // Local
        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
    }
}

allprojects {
    repositories {
        google()
        mavenCentral()
        maven("https://jitpack.io")
    }
}

fun Project.cloudstream(configuration: CloudstreamExtension.() -> Unit) = extensions.getByName<CloudstreamExtension>("cloudstream").configuration()

fun Project.android(configuration: BaseExtension.() -> Unit) = extensions.getByName<BaseExtension>("android").configuration()

subprojects {
    apply(plugin = "com.android.library")
    apply(plugin = "kotlin-android")
    apply(plugin = "com.lagradost.cloudstream3.gradle")

    cloudstream {
        // when running through github workflow, GITHUB_REPOSITORY should contain current repository name
        // you can modify it to use other git hosting services, like gitlab
        setRepo(System.getenv("GITHUB_REPOSITORY") ?: "https://github.com/user/repo")
    }

    android {
        namespace = "recloudstream"

        defaultConfig {
            minSdk = 21
            compileSdkVersion(35)
            targetSdk = 35
        }

        compileOptions {
            sourceCompatibility = JavaVersion.VERSION_1_8
            targetCompatibility = JavaVersion.VERSION_1_8
        }

        tasks.withType<KotlinCompile> {
            compilerOptions {
                // Disables some unnecessary features
                freeCompilerArgs.addAll(
                    listOf(
                        "-Xno-call-assertions",
                        "-Xno-param-assertions",
                        "-Xno-receiver-assertions"
                    )
                )

                jvmTarget.set(JvmTarget.JVM_1_8)  // Required
            }
        }
    }

    dependencies {
        val apk by configurations
        val implementation by configurations

        // Stubs for all Cloudstream classes
        apk("com.lagradost:cloudstream3:pre-release")

        // these dependencies can include any of those which are added by the app,
        // but you dont need to include any of them if you dont need them
        // https://github.com/recloudstream/cloudstream/blob/master/app/build.gradle
        implementation(kotlin("stdlib")) // adds standard kotlin features, like listOf, mapOf etc
        implementation("com.github.Blatzar:NiceHttp:0.4.11") // http library
        implementation("org.jsoup:jsoup:1.16.2") // html parser
    }
}

task<Delete>("clean") {
    delete(rootProject.buildDir)
}
``` 
I will make a corresponding pull requests in the extensions repository and the template repository after this is merged.