### PR TITLE
Add CloudstreamConfigurationProvider

### DIFF
--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/configuration/ApkConfigurationProvider.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/configuration/ApkConfigurationProvider.kt
@@ -1,37 +1,15 @@
 package com.lagradost.cloudstream3.gradle.configuration
 
-import com.lagradost.cloudstream3.gradle.ApkInfo
-import com.lagradost.cloudstream3.gradle.createProgressLogger
-import com.lagradost.cloudstream3.gradle.download
-import com.lagradost.cloudstream3.gradle.getCloudstream
-import groovy.json.JsonSlurper
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
-import java.lang.Integer.parseInt
-import java.net.URL
-import java.nio.file.Files
 
+// Deprecated, use CloudstreamConfigurationProvider
 class ApkConfigurationProvider : IConfigurationProvider {
 
     override val name: String
         get() = "apk"
 
     override fun provide(project: Project, dependency: Dependency) {
-        val extension = project.extensions.getCloudstream()
-        if (extension.apkinfo == null) {
-            extension.apkinfo = ApkInfo(extension, dependency.version ?: "pre-release")
-        }
-        val apkinfo = extension.apkinfo!!
-
-        apkinfo.cache.mkdirs()
-
-        if (!apkinfo.jarFile.exists()) {
-            project.logger.lifecycle("Fetching JAR")
-
-            val url = URL("${apkinfo.urlPrefix}/classes.jar")
-            url.download(apkinfo.jarFile, createProgressLogger(project, "Download JAR"))
-        }
-
-        project.dependencies.add("compileOnly", project.files(apkinfo.jarFile))
+        CloudstreamConfigurationProvider().provide(project, dependency)
     }
 }

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/configuration/CloudstreamConfigurationProvider.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/configuration/CloudstreamConfigurationProvider.kt
@@ -1,0 +1,37 @@
+package com.lagradost.cloudstream3.gradle.configuration
+
+import com.lagradost.cloudstream3.gradle.ApkInfo
+import com.lagradost.cloudstream3.gradle.createProgressLogger
+import com.lagradost.cloudstream3.gradle.download
+import com.lagradost.cloudstream3.gradle.getCloudstream
+import groovy.json.JsonSlurper
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import java.lang.Integer.parseInt
+import java.net.URI
+import java.nio.file.Files
+
+class CloudstreamConfigurationProvider : IConfigurationProvider {
+
+    override val name: String
+        get() = "cloudstream"
+
+    override fun provide(project: Project, dependency: Dependency) {
+        val extension = project.extensions.getCloudstream()
+        if (extension.apkinfo == null) {
+            extension.apkinfo = ApkInfo(extension, dependency.version ?: "pre-release")
+        }
+        val apkinfo = extension.apkinfo!!
+
+        apkinfo.cache.mkdirs()
+
+        if (!apkinfo.jarFile.exists()) {
+            project.logger.lifecycle("Fetching JAR")
+
+            val url = URI("${apkinfo.urlPrefix}/classes.jar").toURL()
+            url.download(apkinfo.jarFile, createProgressLogger(project, "Download JAR"))
+        }
+
+        project.dependencies.add("compileOnly", project.files(apkinfo.jarFile))
+    }
+}

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/configuration/Configurations.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/configuration/Configurations.kt
@@ -3,7 +3,10 @@ package com.lagradost.cloudstream3.gradle.configuration
 import org.gradle.api.Project
 
 fun registerConfigurations(project: Project) {
-    val providers = arrayOf(ApkConfigurationProvider())
+    val providers = arrayOf(
+        ApkConfigurationProvider(),
+        CloudstreamConfigurationProvider()
+    )
 
     for (provider in providers) {
         project.configurations.register(provider.name) {


### PR DESCRIPTION
When using apk - "apk is deprecated; replace with runtimeOnly" so we add a new cloudstream configuration option to avoid this, since we don't want runtimeOnly here. We make ApkConfigurationProvider a wrapper around new CloudstreamConfigurationProvider, and deprecate it. Extensions can now use `val cloudstream by configurations cloudstream("com.lagradost:cloudstream3:pre-release")` instead of `apk` while still maintaining backwards compatibility with `apk`.