### PR TITLE
add option to build jars for cross-platform

### DIFF
--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/CloudstreamExtension.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/CloudstreamExtension.kt
@@ -2,8 +2,6 @@ package com.lagradost.cloudstream3.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionContainer
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.ListProperty
 import javax.inject.Inject
 
 abstract class CloudstreamExtension @Inject constructor(project: Project) {
@@ -82,6 +80,7 @@ abstract class CloudstreamExtension @Inject constructor(project: Project) {
 
     internal var pluginClassName: String? = null
     internal var fileSize: Long? = null
+    internal var jarFileSize: Long? = null
 
     var requiresResources = false
     var description: String? = null
@@ -90,6 +89,11 @@ abstract class CloudstreamExtension @Inject constructor(project: Project) {
     var language: String? = null
     var tvTypes: List<String>? = null
     var iconUrl: String? = null
+    /**
+     * Enable this if your plugin does not use any android imports or app refrences.
+     * This will generate jar files using :make and these files can be checked with :ensureJarCompatibility
+     **/
+    var isCrossPlatform = false
 }
 
 class ApkInfo(extension: CloudstreamExtension, release: String) {

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/Utils.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/Utils.kt
@@ -1,9 +1,7 @@
 package com.lagradost.cloudstream3.gradle
 
 import org.gradle.api.Project
-import com.lagradost.cloudstream3.gradle.getCloudstream
 import com.lagradost.cloudstream3.gradle.entities.*
-import groovy.json.JsonBuilder
 
 fun Project.makeManifest(): PluginManifest {
     val extension = this.extensions.getCloudstream()
@@ -43,11 +41,15 @@ fun Project.makePluginEntry(): PluginEntry {
         internalName = this.name,
         authors = extension.authors,
         description = extension.description,
-        repositoryUrl = (if (repo == null) null else repo.url),
+        repositoryUrl = repo?.url,
         language = extension.language,
         iconUrl = extension.iconUrl,
         apiVersion = extension.apiVersion,
         tvTypes = extension.tvTypes,
-        fileSize = extension.fileSize
+        fileSize = extension.fileSize,
+        jarFileSize = extension.jarFileSize,
+        jarUrl = (
+                if (repo == null || extension.jarFileSize == null) null else repo.getRawLink("${this.name}.jar", extension.buildBranch)
+        ),
     )
 }

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/entities/PluginEntry.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/entities/PluginEntry.kt
@@ -13,5 +13,9 @@ data class PluginEntry(
     val language: String?,
     val tvTypes: List<String>?,
     val iconUrl: String?,
-    val apiVersion: Int
+    val apiVersion: Int,
+
+    // For cross-platform
+    val jarFileSize: Long?,
+    val jarUrl: String?
 )

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
@@ -11,6 +11,9 @@ import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.ByteArrayOutputStream
+import org.gradle.api.GradleException
+import java.io.File
 
 const val TASK_GROUP = "cloudstream"
 
@@ -56,27 +59,103 @@ fun registerTasks(project: Project) {
         it.outputFile.set(intermediates.resolve("classes.dex"))
     }
 
-    val compileResources = project.tasks.register("compileResources", CompileResourcesTask::class.java) {
-        it.group = TASK_GROUP
+    val compileResources =
+        project.tasks.register("compileResources", CompileResourcesTask::class.java) {
+            it.group = TASK_GROUP
 
-        val processManifestTask = project.tasks.getByName("processDebugManifest") as ProcessLibraryManifest
-        it.dependsOn(processManifestTask)
+            val processManifestTask =
+                project.tasks.getByName("processDebugManifest") as ProcessLibraryManifest
+            it.dependsOn(processManifestTask)
 
-        val android = project.extensions.getByName("android") as BaseExtension
-        it.input.set(android.sourceSets.getByName("main").res.srcDirs.single())
-        it.manifestFile.set(processManifestTask.manifestOutputFile)
+            val android = project.extensions.getByName("android") as BaseExtension
+            it.input.set(android.sourceSets.getByName("main").res.srcDirs.single())
+            it.manifestFile.set(processManifestTask.manifestOutputFile)
 
-        it.outputFile.set(intermediates.resolve("res.apk"))
+            it.outputFile.set(intermediates.resolve("res.apk"))
 
-        it.doLast { _ ->
-            val resApkFile = it.outputFile.asFile.get()
+            it.doLast { _ ->
+                val resApkFile = it.outputFile.asFile.get()
 
-            if (resApkFile.exists()) {
-                project.tasks.named("make", AbstractCopyTask::class.java) {
-                    it.from(project.zipTree(resApkFile)) { copySpec ->
-                        copySpec.exclude("AndroidManifest.xml")
+                if (resApkFile.exists()) {
+                    project.tasks.named("make", AbstractCopyTask::class.java) {
+                        it.from(project.zipTree(resApkFile)) { copySpec ->
+                            copySpec.exclude("AndroidManifest.xml")
+                        }
                     }
                 }
+            }
+        }
+
+    val compilePluginJar = project.tasks.register("compilePluginJar") {
+        it.group = TASK_GROUP
+        it.dependsOn("createFullJarDebug") // Ensure JAR is built before copying
+
+        it.doFirst {
+            if (extension.pluginClassName == null) {
+                if (pluginClassFile.exists()) {
+                    extension.pluginClassName = pluginClassFile.readText()
+                }
+            }
+        }
+
+        it.doLast {
+            if (!extension.isCrossPlatform) {
+                return@doLast
+            }
+
+            val jarTask = project.tasks.findByName("createFullJarDebug") ?: return@doLast
+            val jarFile =
+                jarTask.outputs.files.singleFile // Output directory of createFullJarDebug
+            if (jarFile != null) {
+                val targetDir = project.buildDir // Top-level build directory
+                val targetFile = targetDir.resolve("${project.name}.jar")
+                jarFile.copyTo(targetFile, overwrite = true)
+                extension.jarFileSize = jarFile.length()
+                it.logger.lifecycle("Made Cloudstream cross-platform package at ${targetFile.absolutePath}")
+            } else {
+                it.logger.warn("Could not find JAR file!")
+            }
+        }
+    }
+
+    val ensureJarCompatibility = project.tasks.register("ensureJarCompatibility") {
+        it.group = TASK_GROUP
+        it.dependsOn("compilePluginJar")
+        it.doLast { task ->
+            if (!extension.isCrossPlatform) {
+                return@doLast
+            }
+
+            val jarFile = File("${project.buildDir}/${project.name}.jar")
+            if (!jarFile.exists()) {
+                throw GradleException("Jar file does not exist.")
+                return@doLast
+            }
+
+            // Run jdeps command
+            try {
+                val jdepsOutput = ByteArrayOutputStream()
+                val jdepsCommand = listOf("jdeps", "--print-module-deps", jarFile.absolutePath)
+
+                project.exec { execTask ->
+                    execTask.setCommandLine(jdepsCommand)
+                    execTask.setStandardOutput(jdepsOutput)
+                    execTask.setErrorOutput(System.err)
+                    execTask.setIgnoreExitValue(true)
+                }
+
+                val output = jdepsOutput.toString()
+
+                // Check if 'android.' is in the output
+                if (output.isEmpty()) {
+                    task.logger.warn("No output from jdeps! Cannot analyze jar file for Android imports!")
+                } else if (output.contains("android.")) {
+                    throw GradleException("The cross-platform jar file contains Android imports! This will cause compatibility issues.\nRemove 'isCrossPlatform = true' or remove the Android imports.")
+                } else {
+                    task.logger.lifecycle("SUCCESS: The cross-platform jar file does not contain Android imports")
+                }
+            } catch (e: org.gradle.process.internal.ExecException) {
+                task.logger.warn("Jdeps failed! Cannot analyze jar file for Android imports!")
             }
         }
     }
@@ -85,6 +164,9 @@ fun registerTasks(project: Project) {
         val make = project.tasks.register("make", Zip::class.java) {
             val compileDexTask = compileDex.get()
             it.dependsOn(compileDexTask)
+            if (extension.isCrossPlatform) {
+                it.dependsOn(compilePluginJar)
+            }
 
             val manifestFile = intermediates.resolve("manifest.json")
             it.from(manifestFile)
@@ -96,10 +178,11 @@ fun registerTasks(project: Project) {
                 }
 
                 manifestFile.writeText(
-                    JsonBuilder(project.makeManifest(),
+                    JsonBuilder(
+                        project.makeManifest(),
                         JsonGenerator.Options()
-                        .excludeNulls()
-                        .build()
+                            .excludeNulls()
+                            .build()
                     ).toString()
                 )
             }


### PR DESCRIPTION
Using `isCrossPlatform = true` plugins can now also be compiled to jar files.

Example:

```kt
// Use an integer for version numbers
version = 1

cloudstream {
    // All of these properties are optional, you can safely remove any of them.

    description = "Watch livestreams from Twitch"
    authors = listOf("CranberrySoup")

    /**
     * Status int as one of the following:
     * 0: Down
     * 1: Ok
     * 2: Slow
     * 3: Beta-only
     **/
    status = 1 // Will be 3 if unspecified

    tvTypes = listOf("Live")
    iconUrl = "https://www.google.com/s2/favicons?domain=twitch.tv&sz=%size%"
    isCrossPlatform = true
}
```
They can also be checked for compatibility issues using the task `:ensureJarCompatibility`. It searches the jar file for imports containing "android.".

This would enable extension developers to easily support a future cross-platform implementation if their extensions do not directly rely on android.