### PR TITLE
Use v1.2.1 for jadb

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
 
     implementation("org.ow2.asm:asm:9.4")
     implementation("org.ow2.asm:asm-tree:9.4")
-    implementation("com.github.vidstige:jadb:master-SNAPSHOT")
+    implementation("com.github.vidstige:jadb:v1.2.1")
 }
 
 gradlePlugin {


### PR DESCRIPTION
Jitpack is very flaky causing builds for extensions to seem to fail more often then they succeed. This fixes that and some repos have already manually changed this with:
```kt
configurations.all {
        resolutionStrategy.dependencySubstitution {
            substitute(module("com.github.vidstige:jadb:master-SNAPSHOT"))
                .using(module("com.github.vidstige:jadb:v1.2.1"))
        }
    }
```

We should just change it here instead so builds properly work.