### PR TITLE
Getting ready for KMP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
 
     implementation("org.ow2.asm:asm:9.9.1")
     implementation("org.ow2.asm:asm-tree:9.9.1")
-    implementation("com.github.vidstige:jadb:v1.2.1")
+    implementation("com.github.vidstige:jadb:v1.3.0")
 }
 
 gradlePlugin {

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/CloudstreamExtension.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/CloudstreamExtension.kt
@@ -5,8 +5,20 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import javax.inject.Inject
 
-abstract class CloudstreamExtension @Inject constructor(project: Project) {
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This API is experimental and may change in future releases."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR
+)
+annotation class ExperimentalMultiplatform
 
+abstract class CloudstreamExtension @Inject constructor(project: Project) {
     val userCache = project.gradle.gradleUserHomeDir.resolve("caches").resolve("cloudstream")
 
     val apiVersion = 1
@@ -18,6 +30,9 @@ abstract class CloudstreamExtension @Inject constructor(project: Project) {
         internal set
 
     var buildBranch: String = "builds"
+
+    var isNuvioEnabled: Boolean = false
+        internal set
 
     fun overrideUrlPrefix(url: String) {
         if (apkinfo == null) apkinfo = ApkInfo(this, "pre-release")
@@ -31,6 +46,15 @@ abstract class CloudstreamExtension @Inject constructor(project: Project) {
     fun Project.multiplatform(config: KotlinMultiplatformExtension.() -> Unit) {
         extensions.configure<KotlinMultiplatformExtension>("kotlin") { kmp ->
             config.invoke(kmp)
+        }
+    }
+
+    @ExperimentalMultiplatform
+    fun KotlinMultiplatformExtension.nuvio() {
+        isNuvioEnabled = true
+        js {
+            nodejs()
+            binaries.executable()
         }
     }
 

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/CloudstreamExtension.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/CloudstreamExtension.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionContainer
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import javax.inject.Inject
 
 abstract class CloudstreamExtension @Inject constructor(project: Project) {
@@ -25,6 +26,12 @@ abstract class CloudstreamExtension @Inject constructor(project: Project) {
 
     fun setRepo(user: String, repo: String, url: String, rawLinkFormat: String) {
         repository = Repo(user, repo, url, rawLinkFormat)
+    }
+
+    fun Project.multiplatform(config: KotlinMultiplatformExtension.() -> Unit) {
+        extensions.configure<KotlinMultiplatformExtension>("kotlin") { kmp ->
+            config.invoke(kmp)
+        }
     }
 
     fun setRepo(user: String, repo: String, type: String) {

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/LibraryExtensionCompat.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/LibraryExtensionCompat.kt
@@ -3,10 +3,12 @@
 
 package com.lagradost.cloudstream3.gradle
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import java.io.File
 
 /**
@@ -18,13 +20,18 @@ import java.io.File
  */
 internal class LibraryExtensionCompat(private val project: Project) {
 
-    private val android = project.extensions.findByName("android")
-        ?: error("Android plugin not found")
+    private val kmpExtension = project.extensions.findByName("kotlin") as? KotlinMultiplatformExtension?
+    private val android = project.extensions.findByName("android") ?: kmpExtension?.targets?.findByName("android") ?: error("Android plugin not found")
+    private val androidComponents =
+        project.extensions.getByType(
+            com.android.build.api.variant.AndroidComponentsExtension::class.java
+        )
 
     val compileSdk: String
         get() = when (android) {
             is BaseExtension -> android.compileSdkVersion ?: error("compileSdkVersion not found")
             is LibraryExtension -> "android-${android.compileSdk}"
+            is KotlinMultiplatformAndroidLibraryTarget -> "android-${android.compileSdk}"
             else -> error("Android plugin found, but it's not a library module")
         }
 
@@ -32,6 +39,7 @@ internal class LibraryExtensionCompat(private val project: Project) {
         get() = when (android) {
             is BaseExtension -> android.defaultConfig.minSdk ?: 21
             is LibraryExtension -> android.defaultConfig.minSdk ?: 21
+            is KotlinMultiplatformAndroidLibraryTarget -> android.minSdk ?: 21
             else -> error("Android plugin found, but it's not a library module")
         }
 
@@ -39,6 +47,7 @@ internal class LibraryExtensionCompat(private val project: Project) {
         get() = when (android) {
             is BaseExtension -> android.buildToolsVersion
             is LibraryExtension -> android.buildToolsVersion
+            is KotlinMultiplatformAndroidLibraryTarget -> android.buildToolsVersion
             else -> error("Android plugin found, but it's not a library module")
         }
 
@@ -49,6 +58,7 @@ internal class LibraryExtensionCompat(private val project: Project) {
                 .findByType(LibraryAndroidComponentsExtension::class.java)
                 ?.sdkComponents
                 ?.adb?.get()?.asFile ?: error("LibraryAndroidComponentsExtension not found")
+            is KotlinMultiplatformAndroidLibraryTarget -> androidComponents.sdkComponents.adb.get().asFile
             else -> error("Unknown Android extension type")
         }
 
@@ -59,6 +69,8 @@ internal class LibraryExtensionCompat(private val project: Project) {
                 .findByType(LibraryAndroidComponentsExtension::class.java)
                 ?.sdkComponents
                 ?.bootClasspath ?: error("LibraryAndroidComponentsExtension not found")
+            is KotlinMultiplatformAndroidLibraryTarget ->  androidComponents.sdkComponents.bootClasspath
+
             else -> error("Unknown Android extension type")
         }
 
@@ -70,6 +82,8 @@ internal class LibraryExtensionCompat(private val project: Project) {
                 ?.sdkComponents
                 ?.sdkDirectory
                 ?.get()?.asFile ?: error("LibraryAndroidComponentsExtension not found")
+            is KotlinMultiplatformAndroidLibraryTarget -> androidComponents.sdkComponents.sdkDirectory.get().asFile
+
             else -> error("Unknown Android extension type")
         }
 
@@ -82,6 +96,17 @@ internal class LibraryExtensionCompat(private val project: Project) {
                     error(
                         "Resource directory not found at ${dir.path}. " +
                         "Resources are only supported in src/main/res. " +
+                        "If this extension has no resources, remove requiresResources = true."
+                    )
+                }
+                dir
+            }
+            is KotlinMultiplatformAndroidLibraryTarget ->  {
+                val dir = project.layout.projectDirectory.dir("src/androidMain/resources").asFile
+                if (!dir.exists()) {
+                    error(
+                        "Resource directory not found at ${dir.path}. " +
+                        "Resources are only supported in src/androidMain/resources. " +
                         "If this extension has no resources, remove requiresResources = true."
                     )
                 }

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/entities/NuvioPluginEntry.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/entities/NuvioPluginEntry.kt
@@ -1,0 +1,25 @@
+package com.lagradost.cloudstream3.gradle.entities
+
+data class NuvioPluginEntry(
+    val id: String,
+    val name: String,
+    val description: String?,
+    /** Version code as in "1.0.0" */
+    val version: String,
+    val author: String?,
+    /** "movie", "tv",  */
+    val supportedTypes: List<String>,
+    /**  "ProviderName.js" */
+    val filename: String,
+    val enabled: Boolean,
+    /** "mkv", "m3u8", "mp4", "mpd" */
+    val formats: List<String>?,
+    /** Url */
+    val logo: String?,
+    /** "en", "hin" */
+    val contentLanguage: List<String>?,
+    /** "ios" */
+    val disabledPlatforms: List<String>?,
+    val supportsExternalPlayer: Boolean?,
+    val hasSettings: Boolean?,
+)

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/entities/PluginEntry.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/entities/PluginEntry.kt
@@ -19,5 +19,9 @@ data class PluginEntry(
     // For cross-platform
     val jarFileSize: Long?,
     val jarUrl: String?,
-    val jarHash: String?
+    val jarHash: String?,
+
+    val jsFileSize: Long?,
+    val jsUrl: String?,
+    val jsHash: String?,
 )

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJarTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJarTask.kt
@@ -13,13 +13,8 @@ import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class CompilePluginJarTask : DefaultTask() {
-
     @get:Input
     abstract val hasCrossPlatformSupport: Property<Boolean>
-
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.NONE)
-    abstract val pluginClassFile: RegularFileProperty
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJarTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJarTask.kt
@@ -13,9 +13,6 @@ import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class CompilePluginJarTask : DefaultTask() {
-    @get:Input
-    abstract val hasCrossPlatformSupport: Property<Boolean>
-
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val jarInputFile: RegularFileProperty
@@ -25,8 +22,6 @@ abstract class CompilePluginJarTask : DefaultTask() {
 
     @TaskAction
     fun compileJar() {
-        if (!hasCrossPlatformSupport.get()) return
-
         val jarFile = jarInputFile.get().asFile
         val targetFile = targetJarFile.get().asFile
 

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJs.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJs.kt
@@ -1,0 +1,30 @@
+package com.lagradost.cloudstream3.gradle.tasks
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+// Source task, since it skips when no input JS file
+abstract class CompilePluginJsTask : SourceTask() {
+    @get:Input
+    abstract val hasCrossPlatformSupport: Property<Boolean>
+
+    @get:OutputFile
+    abstract val targetJsFile: RegularFileProperty
+
+    @TaskAction
+    fun compileJs() {
+        if (!hasCrossPlatformSupport.get()) return
+
+        val jsFile = this.source.singleFile
+        val targetFile = targetJsFile.asFile.get()
+
+        jsFile.copyTo(targetFile, overwrite = true)
+        logger.lifecycle("Made CloudStream js package at ${targetFile.absolutePath}")
+    }
+}

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJs.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/CompilePluginJs.kt
@@ -1,30 +1,69 @@
 package com.lagradost.cloudstream3.gradle.tasks
 
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 // Source task, since it skips when no input JS file
-abstract class CompilePluginJsTask : SourceTask() {
+abstract class CompilePluginJsTask : DefaultTask() {
     @get:Input
-    abstract val hasCrossPlatformSupport: Property<Boolean>
+    abstract val nuvioEnabled: Property<Boolean>
+
+    @get:Input
+    abstract val pluginName: Property<String>
+
+    @get:InputFile
+    @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val pluginClassFile: RegularFileProperty
+
+    @get:InputDirectory
+    @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val sourceDir: DirectoryProperty
 
     @get:OutputFile
     abstract val targetJsFile: RegularFileProperty
 
     @TaskAction
     fun compileJs() {
-        if (!hasCrossPlatformSupport.get()) return
+        val jsFile = this.sourceDir.asFileTree.find { file ->
+            file.name.endsWith("${pluginName.get()}.js")
+        } ?: return
 
-        val jsFile = this.source.singleFile
         val targetFile = targetJsFile.asFile.get()
-
         jsFile.copyTo(targetFile, overwrite = true)
+
+        val pluginClassName = pluginClassFile.map { it.asFile.readText() }.get()
+
+        // Always load the plugin when JS file is loaded.
+        val initText = """
+            this.${pluginClassName}.prototype.load();
+        """.trimIndent()
+        targetFile.appendText(initText)
+
+        // Load a Nuvio bridge to export the necessary Nuvio methods
+        /*
+        if (this.nuvioEnabled.get()) {
+            val bridgeText = """
+            this.NuvioBridge.init("$pluginClassName");
+            """.trimIndent()
+            targetFile.appendText(bridgeText)
+            logger.lifecycle("Appended CloudStream Nuvio bridge")
+        }
+        */
+
         logger.lifecycle("Made CloudStream js package at ${targetFile.absolutePath}")
     }
 }

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/EnsureJarCompatibilityTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/EnsureJarCompatibilityTask.kt
@@ -20,15 +20,10 @@ abstract class EnsureJarCompatibilityTask : Exec() {
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val jarFile: RegularFileProperty
 
-    @get:Input
-    abstract val hasCrossPlatformSupport: Property<Boolean>
-
     @get:OutputFile
     val outputFile = project.layout.buildDirectory.file("jdeps-output.txt")
 
     override fun exec() {
-        if (!hasCrossPlatformSupport.get()) return
-
         val jar = jarFile.get().asFile
         if (!jar.exists()) throw GradleException("JAR file does not exist: ${jar.absolutePath}")
 

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/MakePluginsJsonTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/MakePluginsJsonTask.kt
@@ -6,23 +6,36 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Property
 
 @CacheableTask
 abstract class MakePluginsJsonTask : DefaultTask() {
 
+    @get:Input
+    abstract val repositoryName: Property<String>
+
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val nuvioOutputFile: RegularFileProperty
 
     @get:InputFiles
     @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val pluginEntryFiles: ConfigurableFileCollection
+
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val nuvioEntryFiles: ConfigurableFileCollection
 
     @TaskAction
     fun makePluginsJson() {
@@ -34,5 +47,24 @@ abstract class MakePluginsJsonTask : DefaultTask() {
         val json = JsonBuilder(entries).toPrettyString()
         outputFile.asFile.get().writeText(json)
         logger.lifecycle("Created ${outputFile.asFile.get()}")
+
+        val nuvioEntries = nuvioEntryFiles.files
+            .filter { it.exists() }
+            .map { slurper.parse(it) }
+
+        if (nuvioEntries.isNotEmpty()) {
+            val manifest = mapOf(
+                "name" to repositoryName.get(),
+                "version" to "1.0.0",
+                "scrapers" to nuvioEntries
+            )
+
+            val nuvioJson = JsonBuilder(manifest).toPrettyString()
+
+            nuvioOutputFile.asFile.get().writeText(nuvioJson)
+            logger.lifecycle("Created ${nuvioOutputFile.asFile.get()}")
+        } else {
+            nuvioOutputFile.asFile.get().delete()
+        }
     }
 }

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
@@ -112,7 +112,7 @@ fun registerTasks(project: Project) {
 
             task.dependsOn(compileDex)
             task.pluginClassFile.set(pluginClassFile)
-            task.nuvioEnabled.set(extension.isNuvioEnabled)
+            task.nuvioEnabled.set(extension.isNuvioEnabled && extension.isCrossPlatform)
             task.targetJsFile.set(project.layout.buildDirectory.file("${project.name}.js"))
 
             val compileJsTaskName = "jsProductionExecutableCompileSync"
@@ -242,7 +242,7 @@ fun registerTasks(project: Project) {
                 task.dependsOn(compilePluginJs)
             }
 
-            task.nuvioEnabled.set(extension.isNuvioEnabled)
+            task.nuvioEnabled.set(extension.isNuvioEnabled && extension.isCrossPlatform)
             task.pluginName.set(project.name)
             task.pluginVersion.set(project.provider {
                 project.version.toString().toIntOrNull(10) ?: -1

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
@@ -52,7 +52,8 @@ fun registerTasks(project: Project) {
         task.minSdk.set(android.minSdk)
         task.bootClasspath.from(android.bootClasspath)
 
-        val kotlinTask = project.tasks.findByName("compileDebugKotlin") as? KotlinCompile
+        val kotlinTask = (project.tasks.findByName("compileDebugKotlin")
+            ?: project.tasks.findByName("compileAndroidMain")) as? KotlinCompile
         if (kotlinTask != null) {
             task.dependsOn(kotlinTask)
             task.input.from(kotlinTask.destinationDirectory)
@@ -68,14 +69,18 @@ fun registerTasks(project: Project) {
             task.group = TASK_GROUP
 
             val processManifestTask =
-                project.tasks.named("processDebugManifest", ProcessLibraryManifest::class.java)
+                (project.tasks.findByName("processDebugManifest")
+                    ?: project.tasks.findByName("processAndroidMainManifest")) as? ProcessLibraryManifest
+                    ?: error("No manifest process task.")
+
             task.dependsOn(processManifestTask)
-
+            task.manifestFile.set(processManifestTask.manifestOutputFile)
             val android = LibraryExtensionCompat(project)
-            task.input.set(android.mainResSrcDir)
 
-            task.manifestFile.set(processManifestTask.flatMap { it.manifestOutputFile })
             task.outputFile.set(resApkFile)
+            if (extension.requiresResources) {
+                task.input.set(android.mainResSrcDir)
+            }
 
             task.aaptExecutable.set(project.layout.file(project.provider {
                 android.sdkDirectory
@@ -92,22 +97,47 @@ fun registerTasks(project: Project) {
             }))
         }
 
-    val compilePluginJar = project.tasks.register("compilePluginJar", CompilePluginJarTask::class.java) { task ->
-        task.group = TASK_GROUP
-        task.dependsOn(compileDex) // compileDex creates pluginClass
-        task.finalizedBy("ensureJarCompatibility") // Ensure compiled JAR is valid
+    val compilePluginJs =
+        project.tasks.register("compilePluginJs", CompilePluginJsTask::class.java) { task ->
+            task.group = TASK_GROUP
+            task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
+            task.targetJsFile.set(project.layout.buildDirectory.file("${project.name}.js"))
 
-        val jarTask = project.tasks.named("createFullJarDebug")
-        task.dependsOn(jarTask) // Ensure JAR is built before copying
+            val compileJsTaskName = "jsProductionExecutableCompileSync"
+            // No source if there is no JS compilation task
+            val compileJsTask = project.tasks.findByName(compileJsTaskName) ?: return@register
 
-        task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
-        task.pluginClassFile.set(pluginClassFile)
-        task.jarInputFile.fileProvider(jarTask.map { it.outputs.files.singleFile })
-        task.targetJarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
-    }
+            task.dependsOn(compileJsTask) // Ensure JS is compiled before copy
+
+            compileJsTask.outputs.files.asFileTree.find { file ->
+                file.name.endsWith(
+                    "${project.name}.js"
+                )
+            }?.let { foundFile ->
+                task.setSource(foundFile)
+            }
+        }
+
+
+    val compilePluginJar =
+        project.tasks.register("compilePluginJar", CompilePluginJarTask::class.java) { task ->
+            task.group = TASK_GROUP
+            task.finalizedBy("ensureJarCompatibility") // Ensure compiled JAR is valid
+
+            val jarTask = project.tasks.findByName("createFullJarDebug")
+                ?: project.tasks.findByName("jvmJar") ?: error("No JAR task available.")
+            task.dependsOn(jarTask) // Ensure JAR is built before copying
+
+            task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
+            task.jarInputFile.fileValue(jarTask.outputs.files.singleFile)
+            task.targetJarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
+        }
 
     val ensureJarCompatibility =
-        project.tasks.register("ensureJarCompatibility", EnsureJarCompatibilityTask::class.java) { task ->
+        project.tasks.register(
+            "ensureJarCompatibility",
+            EnsureJarCompatibilityTask::class.java
+        ) { task ->
             task.dependsOn(compilePluginJar)
             task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
             if (extension.isCrossPlatform) {
@@ -120,31 +150,34 @@ fun registerTasks(project: Project) {
 
     val manifestFile = intermediatesDir.map { it.file("manifest.json") }
 
-    val generateManifest = project.tasks.register("generateManifest", GenerateManifestTask::class.java) { task ->
-        task.group = TASK_GROUP
-        task.dependsOn(compileDex)
+    val generateManifest =
+        project.tasks.register("generateManifest", GenerateManifestTask::class.java) { task ->
+            task.group = TASK_GROUP
+            task.dependsOn(compileDex)
 
-        task.pluginClassFile.set(pluginClassFile)
-        task.outputFile.set(manifestFile)
+            task.pluginClassFile.set(pluginClassFile)
+            task.outputFile.set(manifestFile)
 
-        task.pluginName.set(project.name)
-        task.pluginVersion.set(
-            project.provider {
-                project.version.toString().toIntOrNull(10).also { v ->
-                    if (v == null) project.logger.warn(
-                        "'${project.version}' is not a valid version in ${project.name}. Use an integer."
-                    )
-                } ?: -1
-            }
-        )
-        task.requiresResources.set(extension.requiresResources)
-    }
+            task.pluginName.set(project.name)
+            task.pluginVersion.set(
+                project.provider {
+                    project.version.toString().toIntOrNull(10).also { v ->
+                        if (v == null) project.logger.warn(
+                            "'${project.version}' is not a valid version in ${project.name}. Use an integer."
+                        )
+                    } ?: -1
+                }
+            )
+            task.requiresResources.set(extension.requiresResources)
+        }
 
     val make = project.tasks.register("make", Zip::class.java) { task ->
         task.group = TASK_GROUP
         task.dependsOn(compileDex)
+
         if (extension.isCrossPlatform) {
             task.dependsOn(compilePluginJar)
+            task.dependsOn(compilePluginJs)
         }
 
         task.dependsOn(generateManifest)
@@ -172,40 +205,57 @@ fun registerTasks(project: Project) {
 
     val pluginEntryFile = project.layout.buildDirectory.file("plugin-entry.json")
 
-    val writeCacheEntry = project.tasks.register("writeCacheEntry", WriteCacheEntryTask::class.java) { task ->
-        task.group = TASK_GROUP
-        task.dependsOn(make)
-        if (extension.isCrossPlatform) task.dependsOn(compilePluginJar)
+    val writeCacheEntry =
+        project.tasks.register("writeCacheEntry", WriteCacheEntryTask::class.java) { task ->
+            task.group = TASK_GROUP
+            task.dependsOn(make)
+            if (extension.isCrossPlatform) {
+                task.dependsOn(compilePluginJar)
+                task.dependsOn(compilePluginJs)
+            }
 
-        task.pluginName.set(project.name)
-        task.pluginVersion.set(project.provider {
-            project.version.toString().toIntOrNull(10) ?: -1
-        })
-        task.repoUrl.set(project.provider { extension.repository?.url })
-        task.repoRawLink.set(project.provider { extension.repository?.getRawLink("{file}", extension.buildBranch) })
-        task.buildBranch.set(project.provider { extension.buildBranch })
-        task.status.set(project.provider { extension.status })
-        task.authors.set(project.provider { extension.authors })
-        task.pluginDescription.set(project.provider { extension.description })
-        task.language.set(project.provider { extension.language })
-        task.iconUrl.set(project.provider { extension.iconUrl })
-        task.apiVersion.set(project.provider { extension.apiVersion })
-        task.tvTypes.set(project.provider { extension.tvTypes })
+            task.pluginName.set(project.name)
+            task.pluginVersion.set(project.provider {
+                project.version.toString().toIntOrNull(10) ?: -1
+            })
+            task.repoUrl.set(project.provider { extension.repository?.url })
+            task.repoRawLink.set(project.provider {
+                extension.repository?.getRawLink(
+                    "{file}",
+                    extension.buildBranch
+                )
+            })
+            task.buildBranch.set(project.provider { extension.buildBranch })
+            task.status.set(project.provider { extension.status })
+            task.authors.set(project.provider { extension.authors })
+            task.pluginDescription.set(project.provider { extension.description })
+            task.language.set(project.provider { extension.language })
+            task.iconUrl.set(project.provider { extension.iconUrl })
+            task.apiVersion.set(project.provider { extension.apiVersion })
+            task.tvTypes.set(project.provider { extension.tvTypes })
 
-        task.cs3File.set(make.flatMap { zip ->
-            zip.outputs.files.let { project.layout.buildDirectory.file("${project.name}.cs3") }
-        })
-        if (extension.isCrossPlatform) {
-            task.jarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
+            task.cs3File.set(make.flatMap { zip ->
+                zip.outputs.files.let { project.layout.buildDirectory.file("${project.name}.cs3") }
+            })
+            if (extension.isCrossPlatform) {
+                task.jarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
+                val jsFile = project.layout.buildDirectory.file("${project.name}.js").get()
+                if (jsFile.asFile.exists()) {
+                    task.jsFile.set(jsFile)
+                }
+            }
+            task.outputFile.set(pluginEntryFile)
         }
-        task.outputFile.set(pluginEntryFile)
-    }
 
-    project.rootProject.tasks.named("makePluginsJson", MakePluginsJsonTask::class.java).configure { task ->
-        task.dependsOn(writeCacheEntry)
-        task.mustRunAfter(ensureJarCompatibility)
-        task.pluginEntryFiles.from(pluginEntryFile)
-    }
+    project.rootProject.tasks.named("makePluginsJson", MakePluginsJsonTask::class.java)
+        .configure { task ->
+            task.dependsOn(writeCacheEntry)
+            task.mustRunAfter(ensureJarCompatibility)
+            if (extension.isCrossPlatform) {
+                task.mustRunAfter(compilePluginJs)
+            }
+            task.pluginEntryFiles.from(pluginEntryFile)
+        }
 
     project.tasks.register("cleanCache", CleanCacheTask::class.java) { task ->
         task.group = TASK_GROUP

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
@@ -19,6 +19,8 @@ fun registerTasks(project: Project) {
             task.group = TASK_GROUP
             task.outputs.upToDateWhen { false }
             task.outputFile.set(task.project.layout.buildDirectory.file("plugins.json"))
+            task.nuvioOutputFile.set(task.project.layout.buildDirectory.file("nuvio.json"))
+            task.repositoryName.set(task.project.name)
         }
     }
 
@@ -229,6 +231,7 @@ fun registerTasks(project: Project) {
     }
 
     val pluginEntryFile = project.layout.buildDirectory.file("plugin-entry.json")
+    val nuvioPluginEntryFile = project.layout.buildDirectory.file("nuvio-plugin-entry.json")
 
     val writeCacheEntry =
         project.tasks.register("writeCacheEntry", WriteCacheEntryTask::class.java) { task ->
@@ -239,6 +242,7 @@ fun registerTasks(project: Project) {
                 task.dependsOn(compilePluginJs)
             }
 
+            task.nuvioEnabled.set(extension.isNuvioEnabled)
             task.pluginName.set(project.name)
             task.pluginVersion.set(project.provider {
                 project.version.toString().toIntOrNull(10) ?: -1
@@ -269,17 +273,17 @@ fun registerTasks(project: Project) {
                     task.jsFile.set(jsFile)
                 }
             }
+
             task.outputFile.set(pluginEntryFile)
+            task.nuvioOutputFile.set(nuvioPluginEntryFile)
         }
 
     project.rootProject.tasks.named("makePluginsJson", MakePluginsJsonTask::class.java)
         .configure { task ->
             task.dependsOn(writeCacheEntry)
             task.mustRunAfter(ensureJarCompatibility)
-            if (extension.isCrossPlatform) {
-                task.mustRunAfter(compilePluginJs)
-            }
             task.pluginEntryFiles.from(pluginEntryFile)
+            task.nuvioEntryFiles.from(nuvioPluginEntryFile)
         }
 
     project.tasks.register("cleanCache", CleanCacheTask::class.java) { task ->

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/Tasks.kt
@@ -100,35 +100,55 @@ fun registerTasks(project: Project) {
     val compilePluginJs =
         project.tasks.register("compilePluginJs", CompilePluginJsTask::class.java) { task ->
             task.group = TASK_GROUP
-            task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
+            task.onlyIf("isCrossPlatform must be turned on to compile to JS.") {
+                extension.isCrossPlatform
+            }
+            // Prevent dependencies from being executed
+            if (!extension.isCrossPlatform) {
+                return@register
+            }
+
+            task.dependsOn(compileDex)
+            task.pluginClassFile.set(pluginClassFile)
+            task.nuvioEnabled.set(extension.isNuvioEnabled)
             task.targetJsFile.set(project.layout.buildDirectory.file("${project.name}.js"))
 
             val compileJsTaskName = "jsProductionExecutableCompileSync"
             // No source if there is no JS compilation task
-            val compileJsTask = project.tasks.findByName(compileJsTaskName) ?: return@register
+            val compileJsTask = project.tasks.findByName(compileJsTaskName)
 
-            task.dependsOn(compileJsTask) // Ensure JS is compiled before copy
-
-            compileJsTask.outputs.files.asFileTree.find { file ->
-                file.name.endsWith(
-                    "${project.name}.js"
-                )
-            }?.let { foundFile ->
-                task.setSource(foundFile)
+            val source = compileJsTask?.let { compileTask ->
+                task.dependsOn(compileTask) // Ensure JS is compiled before copy
+                compileTask.outputs.files.singleFile
             }
-        }
 
+            task.onlyIf("There must be a JS output from $compileJsTaskName.") {
+                source != null
+            }
+
+            task.pluginName.set(project.name)
+            task.sourceDir.set(source)
+        }
 
     val compilePluginJar =
         project.tasks.register("compilePluginJar", CompilePluginJarTask::class.java) { task ->
             task.group = TASK_GROUP
-            task.finalizedBy("ensureJarCompatibility") // Ensure compiled JAR is valid
+            task.onlyIf("isCrossPlatform must be turned on to compile to a JAR.") {
+                extension.isCrossPlatform
+            }
+            // Prevent dependencies from being executed
+            if (!extension.isCrossPlatform) {
+                return@register
+            }
 
             val jarTask = project.tasks.findByName("createFullJarDebug")
                 ?: project.tasks.findByName("jvmJar") ?: error("No JAR task available.")
-            task.dependsOn(jarTask) // Ensure JAR is built before copying
 
-            task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
+            if (task.enabled) {
+                task.dependsOn(jarTask) // Ensure JAR is built before copying
+                task.finalizedBy("ensureJarCompatibility") // Ensure compiled JAR is valid
+            }
+
             task.jarInputFile.fileValue(jarTask.outputs.files.singleFile)
             task.targetJarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
         }
@@ -138,13 +158,18 @@ fun registerTasks(project: Project) {
             "ensureJarCompatibility",
             EnsureJarCompatibilityTask::class.java
         ) { task ->
+            task.onlyIf("isCrossPlatform must be turned on to check the JAR file.") {
+                extension.isCrossPlatform
+            }
+            // Prevent dependencies from being executed
+            if (!extension.isCrossPlatform) {
+                return@register
+            }
+
             task.dependsOn(compilePluginJar)
-            task.hasCrossPlatformSupport.set(extension.isCrossPlatform)
-            if (extension.isCrossPlatform) {
-                task.jarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
-                task.doLast {
-                    task.checkOutput()
-                }
+            task.jarFile.set(project.layout.buildDirectory.file("${project.name}.jar"))
+            task.doLast {
+                task.checkOutput()
             }
         }
 

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/WriteCacheEntryTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/WriteCacheEntryTask.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.gradle.tasks
 
+import com.lagradost.cloudstream3.gradle.entities.NuvioPluginEntry
 import com.lagradost.cloudstream3.gradle.entities.PluginEntry
 import groovy.json.JsonBuilder
 import groovy.json.JsonGenerator
@@ -48,7 +49,14 @@ abstract class WriteCacheEntryTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val jsFile: RegularFileProperty
 
-    @get:OutputFile abstract val outputFile: RegularFileProperty
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @get:Input
+    abstract val nuvioEnabled: Property<Boolean>
+
+    @get:OutputFile
+    abstract val nuvioOutputFile: RegularFileProperty
 
     @TaskAction
     fun write() {
@@ -89,6 +97,34 @@ abstract class WriteCacheEntryTask : DefaultTask() {
                 JsonGenerator.Options().excludeNulls().build()
             ).toPrettyString()
         )
+
+        if (nuvioEnabled.get()) {
+            val nuvioEntry = NuvioPluginEntry(
+                name,
+                name,
+                pluginDescription.orNull,
+                "${pluginVersion.orNull ?: 0}.0.0",
+                authors.orNull?.joinToString(),
+                tvTypes.orNull?.map { it.lowercase() } ?: emptyList(),
+                "$name.js",
+                status.orNull != 0,
+                null,
+                iconUrl.orNull,
+                language.orNull?.let { listOf(it) },
+                null,
+                null,
+                false
+            )
+
+            nuvioOutputFile.asFile.get().writeText(
+                JsonBuilder(
+                    nuvioEntry,
+                    JsonGenerator.Options().excludeNulls().build()
+                ).toPrettyString()
+            )
+        } else {
+            nuvioOutputFile.asFile.get().delete()
+        }
     }
 
     private fun sha256(file: File): String {

--- a/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/WriteCacheEntryTask.kt
+++ b/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/WriteCacheEntryTask.kt
@@ -43,12 +43,18 @@ abstract class WriteCacheEntryTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val jarFile: RegularFileProperty
 
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val jsFile: RegularFileProperty
+
     @get:OutputFile abstract val outputFile: RegularFileProperty
 
     @TaskAction
     fun write() {
         val cs3 = cs3File.asFile.get()
         val jar = jarFile.asFile.orNull?.takeIf { it.exists() }
+        val js = jsFile.asFile.orNull?.takeIf { it.exists() }
 
         val name = pluginName.get()
         val rawTemplate = repoRawLink.orNull
@@ -72,6 +78,9 @@ abstract class WriteCacheEntryTask : DefaultTask() {
             jarFileSize = jar?.length(),
             jarUrl = jar?.let { rawLink("${name}.jar") },
             jarHash = jar?.let { sha256(it) },
+            jsFileSize = js?.length(),
+            jsUrl = js?.let { rawLink("${name}.js") },
+            jsHash = js?.let { sha256(it) },
         )
 
         outputFile.asFile.get().writeText(


### PR DESCRIPTION
Can compile KMP projects and normal projects. Features a new CompilePluginJsTask to compile and output js files. 

From my testing it does not contain any breaking changes.

Future changes may be needed for automatic JsExports annotations.